### PR TITLE
feat(rendering): add RENDER_MODE (plain|markdown|auto); support Markd…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,10 @@ BLOG_TITLE=Live Email Blog
 # Optional: Public URL base for RSS links (e.g., when behind a proxy)
 # Example: https://blog.example.com
 PUBLIC_URL=
+
+# Optional: Content rendering mode (defaults to plain)
+# Options: plain | markdown | auto
+# - plain: escape content and render newlines as <br>
+# - markdown: convert plain/markdown to HTML; sanitize; sanitize HTML parts
+# - auto: prefer sanitized text/html part; else markdown->HTML; else plain
+RENDER_MODE=plain

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A secure server that turns your email inbox into a live blog. New emails automat
 - Content Security Policy implementation
 - Memory-efficient (stores last 100 emails)
 - Health check endpoint at /health
+ - Optional Markdown/HTML rendering (opt-in via env var)
 
 ## Installation
 
@@ -37,6 +38,13 @@ pip install -r requirements.txt
      # Base URL used in RSS feed links (useful behind reverse proxies)
      # Example: https://blog.example.com
      PUBLIC_URL=
+     
+     # Optional: Content rendering mode (defaults to plain)
+     # Options: plain | markdown | auto
+     # - plain: escape content and render newlines as <br>
+     # - markdown: convert plain/markdown to HTML; sanitize; sanitize HTML parts
+     # - auto: prefer sanitized text/html part; else markdown->HTML; else plain
+     RENDER_MODE=plain
      ```
 
 3. Run the server:
@@ -63,7 +71,8 @@ If using Gmail:
 - Content Security Policy (CSP) headers
 - X-Frame-Options to prevent clickjacking
 - X-Content-Type-Options to prevent MIME-type sniffing
-- All content is HTML-escaped to prevent XSS attacks
+- By default all content is HTML-escaped to prevent XSS attacks
+- When Markdown/HTML is enabled, content is sanitized (using bleach if installed)
 - No JavaScript used - pure server-side rendering
 - Memory-based caching (no file system access)
 
@@ -73,7 +82,7 @@ If using Gmail:
 2. It uses IMAP IDLE for real-time email notifications
 3. When new emails arrive, they're automatically fetched and cached
 4. The blog page shows the most recent 100 emails
-5. All email content is properly sanitized and encoded
+5. All email content is properly encoded (and sanitized when rendering HTML)
 6. The page auto-updates when you refresh
 
 ## Health Check

--- a/blog_server.py
+++ b/blog_server.py
@@ -21,6 +21,7 @@ async def main():
     port = int(os.getenv("PORT", "8080"))
     blog_title = os.getenv("BLOG_TITLE")
     public_url = os.getenv("PUBLIC_URL")
+    render_mode = os.getenv("RENDER_MODE", "plain")
 
     if not all([imap_server, email_addr, password]):
         logger.error("Please set IMAP_SERVER, EMAIL, and PASSWORD in your .env file")
@@ -35,6 +36,7 @@ async def main():
         port,
         blog_title,
         public_url=public_url,
+        render_mode=render_mode,
     )
     await server.start()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 aiohttp==3.12.15
 aioimaplib==2.0.1
 python-dotenv==1.1.1
+Markdown==3.6
+bleach==6.1.0

--- a/tests/test_render_mode.py
+++ b/tests/test_render_mode.py
@@ -1,0 +1,98 @@
+import unittest
+
+from email_blog_server import EmailBlogServer, emails_cache, processed_uids
+
+
+class RenderModeTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        emails_cache.clear()
+        processed_uids.clear()
+
+    async def test_auto_prefers_html_and_blocks_script(self):
+        server = EmailBlogServer(
+            imap_server="imap.example.com",
+            email_addr="user@example.com",
+            password="secret",
+            host="127.0.0.1",
+            port=8081,
+            blog_title="Test Blog",
+            public_url="http://example.com",
+            enable_imap=False,
+            render_mode="auto",
+        )
+
+        emails_cache.appendleft(
+            {
+                "subject": "HTML Email",
+                "from": "User",
+                "date": "Mon, 01 Jan 2024 12:34:56 +0000",
+                "content": "<b>ok</b><script>alert(1)</script>",
+                "content_type": "text/html",
+                "uid": "2",
+            }
+        )
+        resp = await server.handle_blog(None)
+        html = resp.text
+        # Always blocks script content (sanitized or escaped)
+        self.assertNotIn("<script>", html)
+        self.assertIn("ok", html)
+        # Accept either sanitized <b> or escaped &lt;b&gt;
+        self.assertTrue("<b>ok</b>" in html or "&lt;b&gt;ok&lt;/b&gt;" in html)
+
+    async def test_markdown_mode_blocks_script(self):
+        server = EmailBlogServer(
+            imap_server="imap.example.com",
+            email_addr="user@example.com",
+            password="secret",
+            host="127.0.0.1",
+            port=8081,
+            blog_title="Test Blog",
+            public_url="http://example.com",
+            enable_imap=False,
+            render_mode="markdown",
+        )
+
+        emails_cache.appendleft(
+            {
+                "subject": "MD Email",
+                "from": "User",
+                "date": "Mon, 01 Jan 2024 12:34:56 +0000",
+                "content": "**bold**\n<script>x</script>",
+                "content_type": "text/markdown",
+                "uid": "3",
+            }
+        )
+        resp = await server.handle_blog(None)
+        html = resp.text
+        self.assertNotIn("<script>", html)
+        self.assertIn("bold", html)
+
+    async def test_generate_content_type_defaults_plain(self):
+        server = EmailBlogServer(
+            imap_server="imap.example.com",
+            email_addr="user@example.com",
+            password="secret",
+            host="127.0.0.1",
+            port=8081,
+            blog_title="Test Blog",
+            public_url="http://example.com",
+            enable_imap=False,
+        )
+        # Old entries without content_type should still render safely
+        emails_cache.appendleft(
+            {
+                "subject": "Plain Email",
+                "from": "User",
+                "date": "Mon, 01 Jan 2024 12:34:56 +0000",
+                "content": "line1\nline2",
+                "uid": "4",
+            }
+        )
+        resp = await server.handle_blog(None)
+        html = resp.text
+        self.assertIn("line1<br>line2", html)
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
…own+sanitized HTML; keep plain as default\n\n- Prefer text/html -> text/markdown -> text/plain\n- Optional markdown/bleach with safe fallbacks\n- Expose RENDER_MODE via env; update README and .env.example\n- Add tests for auto/markdown modes\n- Pin Markdown and bleach in requirements.txt