### PR TITLE
[codex] fix email blog security architecture

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ PASSWORD=your-app-password
 
 # Optional settings
 PORT=8080
-HOST=0.0.0.0
+HOST=127.0.0.1
 # Custom title for your blog (defaults to "Live Email Blog" if not set)
 BLOG_TITLE=Live Email Blog
 
@@ -19,3 +19,22 @@ PUBLIC_URL=
 # - markdown: convert plain/markdown to HTML; sanitize; sanitize HTML parts
 # - auto: prefer sanitized text/html part; else markdown->HTML; else plain
 RENDER_MODE=plain
+
+# Optional: mailbox and sender allowlist for posts
+IMAP_MAILBOX=INBOX
+# Comma-separated email addresses. Empty means all senders in the mailbox are accepted.
+ALLOWED_SENDERS=
+
+# Optional: require a token for blog, post, and RSS routes.
+# Send as Authorization: Bearer <token>, X-Blog-Token, or ?token= for RSS readers.
+BLOG_ACCESS_TOKEN=
+
+# Optional: explicit public exposure controls.
+# Required when HOST is 0.0.0.0, ::, or another non-loopback address.
+ALLOW_PUBLIC_BIND=false
+# Only set true when another trusted layer provides access control.
+ALLOW_PUBLIC_WITHOUT_AUTH=false
+
+# Optional: inbound email safety limits
+MAX_EMAIL_BYTES=1048576
+MAX_BODY_CHARS=100000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install dependencies
+        run: |
+          python -m venv .venv
+          .venv/bin/python -m pip install --upgrade pip
+          .venv/bin/python -m pip install -r requirements.txt -r requirements-dev.txt pip-audit
+      - name: Run tests
+        run: make test
+      - name: Run Ruff
+        run: make lint
+      - name: Check formatting
+        run: make format-check
+      - name: Audit dependencies
+        run: .venv/bin/pip-audit -r requirements.txt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,8 @@
 
 ## Project Structure
 - `blog_server.py`: small executable entry point that loads `.env` and starts `EmailBlogServer`.
-- `email_blog_server.py`: reusable server, IMAP ingestion, rendering, RSS, cache, and request-handler logic.
+- `email_blog_server.py`: reusable HTTP server and request-handler orchestration.
+- `email_blog_imap.py`, `email_blog_messages.py`, `email_blog_rendering.py`, `email_blog_feed.py`, `email_blog_html.py`, `email_blog_config.py`: focused helpers for IMAP ingestion, MIME parsing, rendering, RSS, HTML generation, and exposure/auth validation.
 - `templates/blog_template.html`: server-rendered HTML skeleton used by `generate_html`.
 - `tests/`: unittest coverage for runtime modules; async request handlers use `unittest.IsolatedAsyncioTestCase`.
 - `.env.example`: documented configuration contract. Update it whenever adding, renaming, or changing an environment variable.
@@ -30,11 +31,11 @@ make format-check   # black --check .
 Focused validation is preferred while iterating:
 
 ```bash
-python -m unittest tests.test_server
-python -m unittest tests.test_render_mode
-python -m unittest tests.test_server.EmailBlogServerTests.test_health
-ruff check path/to/file.py
-black --check path/to/file.py
+.venv/bin/python -m unittest tests.test_server
+.venv/bin/python -m unittest tests.test_render_mode
+.venv/bin/python -m unittest tests.test_server.EmailBlogServerTests.test_health
+.venv/bin/ruff check path/to/file.py
+.venv/bin/black --check path/to/file.py
 ```
 
 Run `make test` before finishing code changes. Run `make lint` and `make format-check` when Python files changed; use `make format` only when formatting is needed.
@@ -63,7 +64,7 @@ Run `make test` before finishing code changes. Run `make lint` and `make format-
 
 ## Testing Guidelines
 - Add or update tests for every feature or bug fix, including at least one positive case and one failure, escaping, or sanitization case when user-controlled content is involved.
-- Reset shared state in `setUp` with `emails_cache.clear()` and `processed_uids.clear()`.
+- Keep cache state instance-owned in tests by using `server.emails_cache` and `server.processed_uids`.
 - Keep tests deterministic: avoid wall-clock assertions unless values are controlled, avoid network access, and do not require real environment variables.
 - Prefer focused unittest targets while developing, then run the full suite with `make test`.
 - Rendering changes should verify the emitted HTML or RSS text for both intended output and blocked unsafe content.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
 .PHONY: help install install-dev run test lint lint-fix format format-check
 
+VENV ?= .venv
+PYTHON ?= $(VENV)/bin/python
+PIP ?= $(PYTHON) -m pip
+RUFF ?= $(VENV)/bin/ruff
+BLACK ?= $(VENV)/bin/black
+
 help:
 	@echo "Available targets:"
 	@echo "  install        - pip install -r requirements.txt"
@@ -11,27 +17,29 @@ help:
 	@echo "  format         - run black formatter"
 	@echo "  format-check   - check formatting with black"
 
-install:
-	pip install -r requirements.txt
+$(PYTHON):
+	python3 -m venv $(VENV)
+
+install: $(PYTHON)
+	$(PIP) install -r requirements.txt
 
 install-dev: install
-	pip install -r requirements-dev.txt
+	$(PIP) install -r requirements-dev.txt
 
 run:
-	python blog_server.py
+	$(PYTHON) blog_server.py
 
 test:
-	python -m unittest discover -s tests -p 'test_*.py'
+	$(PYTHON) -m unittest discover -s tests -p 'test_*.py'
 
 lint:
-	ruff check .
+	$(RUFF) check .
 
 lint-fix:
-	ruff check --fix .
+	$(RUFF) check --fix .
 
 format:
-	black .
+	$(BLACK) .
 
 format-check:
-	black --check .
-
+	$(BLACK) --check .

--- a/README.md
+++ b/README.md
@@ -11,13 +11,15 @@ A secure server that turns your email inbox into a live blog. New emails automat
 - Content Security Policy implementation
 - Memory-efficient (stores last 100 emails)
 - Health check endpoint at /health
- - Optional Markdown/HTML rendering (opt-in via env var)
+- Optional Markdown/HTML rendering (opt-in via env var)
+- Stable IMAP UID-based post links
+- Optional token authentication, mailbox selection, and sender allowlisting
 
 ## Installation
 
 1. Install Python dependencies:
 ```bash
-pip install -r requirements.txt
+make install
 ```
 
 2. Configure environment variables:
@@ -34,7 +36,7 @@ pip install -r requirements.txt
 
      # Optional settings
      PORT=8080
-     HOST=0.0.0.0
+     HOST=127.0.0.1
      # Base URL used in RSS feed links (useful behind reverse proxies)
      # Example: https://blog.example.com
      PUBLIC_URL=
@@ -45,14 +47,34 @@ pip install -r requirements.txt
      # - markdown: convert plain/markdown to HTML; sanitize; sanitize HTML parts
      # - auto: prefer sanitized text/html part; else markdown->HTML; else plain
      RENDER_MODE=plain
+
+     # Optional: publish from a dedicated mailbox and/or trusted senders only
+     IMAP_MAILBOX=INBOX
+     ALLOWED_SENDERS=
+
+     # Optional: require a token on blog, post, and RSS routes
+     BLOG_ACCESS_TOKEN=
+
+     # Required to bind to 0.0.0.0, ::, or a non-loopback address
+     ALLOW_PUBLIC_BIND=false
+     # Only set true when a trusted reverse proxy or VPN already protects access
+     ALLOW_PUBLIC_WITHOUT_AUTH=false
+
+     # Optional: inbound email size limits
+     MAX_EMAIL_BYTES=1048576
+     MAX_BODY_CHARS=100000
      ```
 
 3. Run the server:
 ```bash
-python blog_server.py
+make run
 ```
 
 4. Visit `http://localhost:8080` in your browser to view your email blog
+
+By default the server binds only to `127.0.0.1`. To expose it publicly, set
+`ALLOW_PUBLIC_BIND=true` and configure `BLOG_ACCESS_TOKEN`, or keep the server behind a trusted
+reverse proxy/VPN and explicitly set `ALLOW_PUBLIC_WITHOUT_AUTH=true`.
 
 ## Gmail Setup
 
@@ -68,22 +90,31 @@ If using Gmail:
 ## Security Features
 
 - SSL/TLS encryption for email fetching
+- Loopback-only default binding
+- Optional token authentication for blog, post, and RSS routes
+- Optional dedicated mailbox and sender allowlist
+- Stable IMAP UID-based links instead of shifting sequence numbers
+- Message and body size limits to reduce memory abuse
+- Attachments are skipped during body extraction
 - Content Security Policy (CSP) headers
 - X-Frame-Options to prevent clickjacking
 - X-Content-Type-Options to prevent MIME-type sniffing
 - By default all content is HTML-escaped to prevent XSS attacks
 - When Markdown/HTML is enabled, content is sanitized (using bleach if installed)
+- RSS is generated with XML APIs instead of manual string interpolation
 - No JavaScript used - pure server-side rendering
 - Memory-based caching (no file system access)
 
 ## How It Works
 
-1. The server connects to your email inbox using IMAP over SSL
+1. The server connects to your configured mailbox using IMAP over SSL
 2. It uses IMAP IDLE for real-time email notifications
-3. When new emails arrive, they're automatically fetched and cached
-4. The blog page shows the most recent 100 emails
-5. All email content is properly encoded (and sanitized when rendering HTML)
-6. The page auto-updates when you refresh
+3. It searches and fetches messages by stable IMAP UID
+4. Oversized messages and attachments are skipped before rendering
+5. When new emails arrive, they're automatically fetched and cached
+6. The blog page shows the most recent 100 emails
+7. All email content is properly encoded (and sanitized when rendering HTML)
+8. The page auto-updates when you refresh
 
 ## Health Check
 
@@ -91,9 +122,9 @@ The server provides a health check endpoint at `/health` that returns "OK" when 
 ## Development
 
 - Run locally:
-  - `python blog_server.py`
+  - `make run`
 - Tests (unit tests focus on rendering and RSS; IMAP is disabled during tests):
-  - `python -m unittest discover -s tests -p 'test_*.py'`
+  - `make test`
 
 - Dev tooling:
   - Install: `make install-dev`

--- a/blog_server.py
+++ b/blog_server.py
@@ -1,7 +1,9 @@
 import asyncio
 import logging
 import os
+
 from dotenv import load_dotenv
+
 from email_blog_server import EmailBlogServer
 
 # Configure logging
@@ -9,7 +11,29 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-async def main():
+def parse_bool(value: str | None) -> bool:
+    """Parse common truthy environment values."""
+    return (value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def parse_int(name: str, default: int) -> int:
+    """Parse an integer environment variable with a clear error."""
+    value = os.getenv(name)
+    if value is None or value == "":
+        return default
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise SystemExit(f"{name} must be an integer") from exc
+
+
+def parse_csv(name: str) -> list[str]:
+    """Parse a comma-separated environment variable."""
+    return [item.strip() for item in os.getenv(name, "").split(",") if item.strip()]
+
+
+async def main() -> None:
+    """Load configuration and run the email blog server."""
     # Load environment variables from .env file
     load_dotenv()
 
@@ -17,15 +41,22 @@ async def main():
     imap_server = os.getenv("IMAP_SERVER")
     email_addr = os.getenv("EMAIL")
     password = os.getenv("PASSWORD")
-    host = os.getenv("HOST", "0.0.0.0")
-    port = int(os.getenv("PORT", "8080"))
+    host = os.getenv("HOST", "127.0.0.1")
+    port = parse_int("PORT", 8080)
     blog_title = os.getenv("BLOG_TITLE")
     public_url = os.getenv("PUBLIC_URL")
     render_mode = os.getenv("RENDER_MODE", "plain")
+    mailbox = os.getenv("IMAP_MAILBOX", "INBOX")
+    access_token = os.getenv("BLOG_ACCESS_TOKEN")
+    allowed_senders = parse_csv("ALLOWED_SENDERS")
+    max_email_bytes = parse_int("MAX_EMAIL_BYTES", 1_048_576)
+    max_body_chars = parse_int("MAX_BODY_CHARS", 100_000)
+    allow_public_bind = parse_bool(os.getenv("ALLOW_PUBLIC_BIND"))
+    allow_public_without_auth = parse_bool(os.getenv("ALLOW_PUBLIC_WITHOUT_AUTH"))
 
     if not all([imap_server, email_addr, password]):
         logger.error("Please set IMAP_SERVER, EMAIL, and PASSWORD in your .env file")
-        exit(1)
+        raise SystemExit(1)
 
     # Create and start the server
     server = EmailBlogServer(
@@ -37,15 +68,16 @@ async def main():
         blog_title,
         public_url=public_url,
         render_mode=render_mode,
+        mailbox=mailbox,
+        access_token=access_token,
+        allowed_senders=allowed_senders,
+        max_email_bytes=max_email_bytes,
+        max_body_chars=max_body_chars,
+        allow_public_bind=allow_public_bind,
+        allow_public_without_auth=allow_public_without_auth,
     )
     await server.start()
-
-    try:
-        # Keep the server running
-        while True:
-            await asyncio.sleep(3600)  # Sleep for an hour
-    except asyncio.CancelledError:
-        logger.info("Server shutdown initiated...")
+    await server.wait_closed()
 
 
 if __name__ == "__main__":

--- a/email_blog_config.py
+++ b/email_blog_config.py
@@ -1,0 +1,63 @@
+"""Validate exposure and authentication configuration."""
+
+from __future__ import annotations
+
+import ipaddress
+import secrets
+from urllib.parse import urlparse
+
+from aiohttp import web
+
+CONTENT_SECURITY_POLICY = "default-src 'none'; style-src 'unsafe-inline'; base-uri 'self';"
+DEFAULT_MAX_EMAIL_BYTES = 1_048_576
+DEFAULT_MAX_BODY_CHARS = 100_000
+
+
+def request_has_token(request: web.Request, expected_token: str) -> bool:
+    """Return whether a request presents the configured access token."""
+    auth_header = request.headers.get("Authorization", "")
+    candidates = [
+        auth_header.removeprefix("Bearer ").strip(),
+        request.headers.get("X-Blog-Token", ""),
+        request.query.get("token", ""),
+    ]
+    return any(secrets.compare_digest(token, expected_token) for token in candidates if token)
+
+
+def validate_public_url(public_url: str | None) -> str | None:
+    """Validate and normalize a configured public base URL."""
+    if not public_url:
+        return None
+    parsed = urlparse(public_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError("PUBLIC_URL must be an absolute http(s) URL")
+    return public_url.rstrip("/")
+
+
+def validate_exposure(
+    host: str,
+    access_token: str | None,
+    allow_public_bind: bool,
+    allow_public_without_auth: bool,
+) -> None:
+    """Reject accidental public binding without explicit exposure settings."""
+    if not is_public_bind(host):
+        return
+    if not allow_public_bind:
+        raise ValueError("Public HOST binding requires ALLOW_PUBLIC_BIND=true")
+    if not access_token and not allow_public_without_auth:
+        raise ValueError(
+            "Public HOST binding requires BLOG_ACCESS_TOKEN or ALLOW_PUBLIC_WITHOUT_AUTH=true"
+        )
+
+
+def is_public_bind(host: str) -> bool:
+    """Return whether a host binding is reachable beyond loopback."""
+    if host in {"", "0.0.0.0", "::"}:
+        return True
+    if host.lower() == "localhost":
+        return False
+    try:
+        return not ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return True

--- a/email_blog_feed.py
+++ b/email_blog_feed.py
@@ -1,0 +1,49 @@
+"""Build RSS output for the email blog."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from email.utils import formatdate, parsedate_to_datetime
+from xml.etree import ElementTree
+
+
+def build_rss(emails: list[dict[str, str]], blog_title: str, base_url: str) -> str:
+    """Build an XML-safe RSS 2.0 feed for cached email posts."""
+    root = ElementTree.Element("rss", version="2.0")
+    channel = ElementTree.SubElement(root, "channel")
+    _add_text(channel, "title", blog_title)
+    _add_text(channel, "link", base_url)
+    _add_text(channel, "description", blog_title)
+    _add_text(channel, "language", "en-us")
+    _add_text(channel, "lastBuildDate", formatdate(usegmt=True))
+
+    for email_data in emails:
+        item = ElementTree.SubElement(channel, "item")
+        post_url = f"{base_url}/email/{email_data['uid']}"
+        _add_text(item, "title", email_data["subject"])
+        _add_text(item, "link", post_url)
+        _add_text(item, "guid", post_url)
+        _add_text(item, "description", email_data["content"])
+        _add_text(item, "author", email_data["from"])
+        _add_text(item, "pubDate", _rss_date(email_data.get("date", "")))
+
+    xml_body = ElementTree.tostring(root, encoding="unicode", short_empty_elements=False)
+    return f'<?xml version="1.0" encoding="UTF-8" ?>\n{xml_body}'
+
+
+def _add_text(parent: ElementTree.Element, tag: str, text: str) -> None:
+    child = ElementTree.SubElement(parent, tag)
+    child.text = text or ""
+
+
+def _rss_date(date_text: str) -> str:
+    try:
+        dt = parsedate_to_datetime(date_text)
+        if dt is None:
+            raise ValueError("parsedate_to_datetime returned None")
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=UTC)
+        timestamp = float(dt.timestamp())
+    except Exception:
+        timestamp = float(datetime.now(tz=UTC).timestamp())
+    return formatdate(timestamp, usegmt=True)

--- a/email_blog_html.py
+++ b/email_blog_html.py
@@ -1,0 +1,63 @@
+"""Generate HTML pages for the email blog."""
+
+from __future__ import annotations
+
+import html
+from datetime import datetime
+from pathlib import Path
+from urllib.parse import quote
+
+from email_blog_rendering import render_content_to_html
+
+
+def build_blog_html(
+    template_path: Path,
+    blog_title: str,
+    emails: list[dict[str, str]],
+    render_mode: str,
+    single_email: dict[str, str] | None = None,
+) -> str:
+    """Render the blog index or single-post HTML page."""
+    email_content = (
+        build_email_html(single_email, render_mode)
+        if single_email
+        else "".join(
+            build_email_html(email_data, render_mode, linked=True) for email_data in emails
+        )
+    )
+
+    template = template_path.read_text()
+    replacements = {
+        "{title}": html.escape(blog_title),
+        "{last_updated}": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        "{email_content}": email_content,
+    }
+    for key, value in replacements.items():
+        template = template.replace(key, value)
+    return template
+
+
+def build_email_html(
+    email_data: dict[str, str],
+    render_mode: str,
+    linked: bool = False,
+) -> str:
+    """Render a single email post as an HTML article."""
+    title = html.escape(email_data["subject"])
+    if linked:
+        uid = quote(str(email_data["uid"]), safe="")
+        title = f'<a href="/email/{html.escape(uid)}">{title}</a>'
+
+    back_link = "" if linked else '<p><a href="/">&larr; Back to all emails</a></p>'
+    return f"""
+        <article>
+            <h2>{title}</h2>
+            <div class="meta">
+                <p><strong>From:</strong> {html.escape(email_data['from'])}</p>
+                <p><strong>Date:</strong> {html.escape(email_data['date'])}</p>
+            </div>
+            <div class="content">
+                {render_content_to_html(email_data.get('content', ''), email_data.get('content_type') or 'text/plain', render_mode)}
+            </div>
+            {back_link}
+        </article>"""

--- a/email_blog_imap.py
+++ b/email_blog_imap.py
@@ -101,7 +101,11 @@ class EmailBlogImapMixin:
         uids = parse_id_list(data) if status == "OK" else []
         logger.info("Found %s message UIDs", len(uids))
 
-        for uid in uids[-100:] if limit_to_recent else uids:
+        uids_to_fetch = uids[-100:] if limit_to_recent else uids
+        if limit_to_recent:
+            self.processed_uids.update(set(uids) - set(uids_to_fetch))
+
+        for uid in uids_to_fetch:
             if uid in self.processed_uids:
                 continue
             email_data = await self.fetch_email(uid)

--- a/email_blog_imap.py
+++ b/email_blog_imap.py
@@ -1,0 +1,146 @@
+"""Manage IMAP connections and message ingestion."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import ssl
+
+from aioimaplib import aioimaplib
+
+from email_blog_messages import (
+    extract_fetch_message_bytes,
+    parse_email_message,
+    parse_id_list,
+    parse_rfc822_size,
+    parse_uid_validity,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class EmailBlogImapMixin:
+    """Provide IMAP UID search, fetch, and IDLE monitoring behavior."""
+
+    async def connect_imap(self) -> bool:
+        """Establish a TLS-protected IMAP connection and select the configured mailbox."""
+        try:
+            ssl_context = ssl.create_default_context()
+            logger.info("Creating IMAP client for %s", self.imap_server)
+            self.imap_client = aioimaplib.IMAP4_SSL(host=self.imap_server, ssl_context=ssl_context)
+
+            await self.imap_client.wait_hello_from_server()
+            await self.imap_client.login(self.email_addr, self.password)
+            status, data = await self.imap_client.select(self.mailbox)
+            if status != "OK":
+                raise RuntimeError(f"Unable to select mailbox {self.mailbox!r}: {data}")
+
+            self._set_uid_validity(parse_uid_validity(data))
+            logger.info("Connected to IMAP mailbox %s", self.mailbox)
+            return True
+        except Exception as exc:
+            logger.error("Failed to connect to IMAP: %s", exc, exc_info=True)
+            return False
+
+    async def fetch_email(self, uid: str) -> dict[str, str] | None:
+        """Fetch and process a single email by stable IMAP UID."""
+        try:
+            status, data = await self.imap_client.uid("FETCH", uid, "(RFC822.SIZE)")
+            if status != "OK":
+                logger.error("Size fetch failed for UID %s: %s", uid, data)
+                return None
+
+            message_size = parse_rfc822_size(data)
+            if message_size is not None and message_size > self.max_email_bytes:
+                logger.warning("Skipping UID %s because size %s exceeds limit", uid, message_size)
+                return None
+
+            status, data = await self.imap_client.uid("FETCH", uid, "(BODY.PEEK[])")
+        except Exception as exc:
+            logger.error("Fetch failed for UID %s: %s", uid, exc)
+            return None
+
+        if status != "OK":
+            logger.error("Body fetch failed for UID %s: %s", uid, data)
+            return None
+
+        msg_bytes = extract_fetch_message_bytes(data)
+        if not msg_bytes:
+            logger.error("Unexpected FETCH response format for UID %s: %s", uid, data)
+            return None
+        if len(msg_bytes) > self.max_email_bytes:
+            logger.warning("Skipping UID %s because payload exceeds limit", uid)
+            return None
+
+        return parse_email_message(
+            uid,
+            msg_bytes,
+            allowed_senders=self.allowed_senders,
+            max_body_chars=self.max_body_chars,
+        )
+
+    async def monitor_inbox(self) -> None:
+        """Monitor the mailbox for new messages using IMAP IDLE."""
+        while True:
+            try:
+                logger.info("Connecting to %s as %s", self.imap_server, self.email_addr)
+                if not await self.connect_imap():
+                    await asyncio.sleep(10)
+                    continue
+
+                await self._fetch_new_uids(limit_to_recent=True)
+                await self._idle_until_new_message()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.error("Error in monitor_inbox: %s", exc)
+                await asyncio.sleep(30)
+
+    async def _fetch_new_uids(self, limit_to_recent: bool = False) -> None:
+        status, data = await self.imap_client.uid("SEARCH", "ALL")
+        uids = parse_id_list(data) if status == "OK" else []
+        logger.info("Found %s message UIDs", len(uids))
+
+        for uid in uids[-100:] if limit_to_recent else uids:
+            if uid in self.processed_uids:
+                continue
+            email_data = await self.fetch_email(uid)
+            self.processed_uids.add(uid)
+            if email_data:
+                self._append_email(email_data)
+
+    async def _idle_until_new_message(self) -> None:
+        await self.imap_client.idle_start()
+        try:
+            while True:
+                response = await self.imap_client.wait_server_push()
+                if response is None:
+                    logger.info("IDLE connection closed, reconnecting")
+                    return
+                if any(b"EXISTS" in line for line in response):
+                    await self.imap_client.idle_done()
+                    await self._fetch_new_uids()
+                    await self.imap_client.idle_start()
+        finally:
+            if self.imap_client and self.imap_client.has_pending_idle():
+                await self.imap_client.idle_done()
+
+    def _set_uid_validity(self, uid_validity: str | None) -> None:
+        if uid_validity and self.uid_validity and uid_validity != self.uid_validity:
+            logger.warning("UIDVALIDITY changed; clearing cached posts and processed UIDs")
+            with self._cache_lock:
+                self.emails_cache.clear()
+            self.processed_uids.clear()
+        self.uid_validity = uid_validity or self.uid_validity
+
+    async def _close_imap(self) -> None:
+        if not self.imap_client:
+            return
+        try:
+            if self.imap_client.has_pending_idle():
+                await self.imap_client.idle_done()
+            await self.imap_client.logout()
+        except Exception as exc:
+            logger.error("Error during IMAP cleanup: %s", exc)
+        finally:
+            self.imap_client = None

--- a/email_blog_messages.py
+++ b/email_blog_messages.py
@@ -1,0 +1,188 @@
+"""Parse IMAP fetch responses and extract publishable email bodies."""
+
+from __future__ import annotations
+
+import email
+import re
+from collections.abc import Iterable
+from email.header import decode_header
+from email.message import Message
+from email.utils import getaddresses
+
+MARKDOWN_TYPES = {"text/markdown", "text/x-markdown"}
+TEXT_TYPES = {"text/html", *MARKDOWN_TYPES, "text/plain"}
+TRUNCATION_NOTICE = "\n\n[Message truncated at {limit} characters.]"
+
+
+def safe_decode(header: str | None) -> str:
+    """Decode an RFC 2047 email header without raising on bad input."""
+    if not header:
+        return ""
+
+    parts = []
+    for content, charset in decode_header(header):
+        if isinstance(content, bytes):
+            try:
+                parts.append(content.decode(charset or "utf-8", errors="replace"))
+            except Exception:
+                parts.append(content.decode("utf-8", errors="replace"))
+        else:
+            parts.append(str(content))
+    return " ".join(parts)
+
+
+def sender_allowed(from_header: str, allowed_senders: Iterable[str] | None) -> bool:
+    """Return whether a decoded From header matches the optional sender allowlist."""
+    allowed = {sender.strip().lower() for sender in allowed_senders or [] if sender.strip()}
+    if not allowed:
+        return True
+
+    addresses = {addr.lower() for _, addr in getaddresses([from_header]) if addr}
+    names = {name.lower() for name, _ in getaddresses([from_header]) if name}
+    return bool((addresses | names) & allowed)
+
+
+def extract_email_content(
+    msg: Message,
+    max_body_chars: int | None = None,
+) -> tuple[str, str]:
+    """Extract the best inline text body and its MIME type from a message."""
+    preferred: dict[str, str | None] = {
+        "text/html": None,
+        "text/markdown": None,
+        "text/plain": None,
+    }
+
+    for part in msg.walk() if msg.is_multipart() else [msg]:
+        if part.is_multipart() or part.get_content_disposition() == "attachment":
+            continue
+
+        ctype = part.get_content_type() or "text/plain"
+        if ctype not in TEXT_TYPES:
+            continue
+
+        body = _decode_text_part(part)
+        if body is None:
+            continue
+
+        if ctype in MARKDOWN_TYPES:
+            ctype = "text/markdown"
+        if preferred[ctype] is None:
+            preferred[ctype] = _limit_text(body, max_body_chars)
+
+    for ctype in ("text/html", "text/markdown", "text/plain"):
+        if preferred[ctype] is not None:
+            return preferred[ctype] or "", ctype
+
+    return "Could not decode email content", "text/plain"
+
+
+def parse_email_message(
+    uid: str,
+    msg_bytes: bytes,
+    allowed_senders: Iterable[str] | None = None,
+    max_body_chars: int | None = None,
+) -> dict[str, str] | None:
+    """Parse a raw email message into the internal blog-post dictionary."""
+    msg = email.message_from_bytes(msg_bytes)
+    subject = safe_decode(msg["subject"])
+    from_addr = safe_decode(msg["from"])
+
+    if not sender_allowed(from_addr, allowed_senders):
+        return None
+
+    content, content_type = extract_email_content(msg, max_body_chars=max_body_chars)
+    return {
+        "subject": subject,
+        "from": from_addr,
+        "date": safe_decode(msg["date"]),
+        "content": content,
+        "content_type": content_type,
+        "uid": str(uid),
+        "message_id": safe_decode(msg["message-id"]),
+    }
+
+
+def parse_rfc822_size(data: object) -> int | None:
+    """Parse RFC822.SIZE from an IMAP FETCH response."""
+    for item in _flatten_response_items(data):
+        text = item.decode("ascii", errors="ignore") if isinstance(item, bytes) else str(item)
+        match = re.search(r"RFC822\.SIZE\s+(\d+)", text, flags=re.IGNORECASE)
+        if match:
+            return int(match.group(1))
+    return None
+
+
+def parse_uid_validity(data: object) -> str | None:
+    """Parse UIDVALIDITY from an IMAP SELECT response."""
+    for item in _flatten_response_items(data):
+        text = item.decode("ascii", errors="ignore") if isinstance(item, bytes) else str(item)
+        match = re.search(r"UIDVALIDITY\s+(\d+)", text, flags=re.IGNORECASE)
+        if match:
+            return match.group(1)
+    return None
+
+
+def extract_fetch_message_bytes(data: object) -> bytes | None:
+    """Extract raw message bytes from common aioimaplib FETCH response shapes."""
+    candidates = [item for item in _flatten_response_items(data) if isinstance(item, bytes)]
+    message_candidates = [
+        item
+        for item in candidates
+        if (b"\r\n\r\n" in item or b"\n\n" in item) and not item.lstrip().startswith(b"* ")
+    ]
+    if message_candidates:
+        return max(message_candidates, key=len)
+
+    non_metadata = [
+        item
+        for item in candidates
+        if not item.lstrip().startswith((b"* ", b")")) and b"FETCH" not in item[:80].upper()
+    ]
+    return max(non_metadata, key=len) if non_metadata else None
+
+
+def parse_id_list(data: object) -> list[str]:
+    """Parse a SEARCH response containing space-separated IDs."""
+    for item in _flatten_response_items(data):
+        if isinstance(item, bytes):
+            text = item.decode("ascii", errors="ignore").strip()
+        else:
+            text = str(item).strip()
+        if text and all(part.isdigit() for part in text.split()):
+            return text.split()
+    return []
+
+
+def _decode_text_part(part: Message) -> str | None:
+    payload = part.get_payload(decode=True)
+    if payload is None:
+        raw_payload = part.get_payload()
+        return raw_payload if isinstance(raw_payload, str) else None
+
+    charset = part.get_content_charset() or "utf-8"
+    try:
+        return payload.decode(charset, errors="replace")
+    except LookupError:
+        return payload.decode("utf-8", errors="replace")
+
+
+def _limit_text(text: str, limit: int | None) -> str:
+    if limit is None or limit <= 0 or len(text) <= limit:
+        return text
+    return text[:limit] + TRUNCATION_NOTICE.format(limit=limit)
+
+
+def _flatten_response_items(data: object) -> list[object]:
+    if isinstance(data, tuple):
+        return list(data)
+    if not isinstance(data, list):
+        return [data]
+
+    flattened = []
+    for item in data:
+        if isinstance(item, tuple):
+            flattened.extend(item)
+        else:
+            flattened.append(item)
+    return flattened

--- a/email_blog_messages.py
+++ b/email_blog_messages.py
@@ -38,8 +38,7 @@ def sender_allowed(from_header: str, allowed_senders: Iterable[str] | None) -> b
         return True
 
     addresses = {addr.lower() for _, addr in getaddresses([from_header]) if addr}
-    names = {name.lower() for name, _ in getaddresses([from_header]) if name}
-    return bool((addresses | names) & allowed)
+    return bool(addresses & allowed)
 
 
 def extract_email_content(

--- a/email_blog_rendering.py
+++ b/email_blog_rendering.py
@@ -1,0 +1,106 @@
+"""Render email bodies into safe HTML."""
+
+from __future__ import annotations
+
+import html
+
+try:
+    import markdown as _markdown  # type: ignore
+
+    _MARKDOWN_AVAILABLE = True
+except Exception:
+    _markdown = None
+    _MARKDOWN_AVAILABLE = False
+
+try:
+    import bleach  # type: ignore
+
+    _BLEACH_AVAILABLE = True
+except Exception:
+    bleach = None
+    _BLEACH_AVAILABLE = False
+
+
+ALLOWED_TAGS = [
+    "p",
+    "br",
+    "hr",
+    "pre",
+    "code",
+    "blockquote",
+    "ul",
+    "ol",
+    "li",
+    "strong",
+    "em",
+    "b",
+    "i",
+    "u",
+    "s",
+    "a",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+]
+ALLOWED_ATTRIBUTES = {"a": ["href", "title", "rel"]}
+ALLOWED_PROTOCOLS = ["http", "https", "mailto"]
+
+
+def escape_plain_text(text: str) -> str:
+    """Escape plain text and preserve line breaks."""
+    return html.escape(text).replace("\n", "<br>")
+
+
+def sanitize_html(html_in: str) -> str:
+    """Remove unsafe HTML while preserving a small publishing-oriented subset."""
+    if not _BLEACH_AVAILABLE:
+        return escape_plain_text(html_in)
+
+    cleaned = bleach.clean(
+        html_in,
+        tags=ALLOWED_TAGS,
+        attributes=ALLOWED_ATTRIBUTES,
+        protocols=ALLOWED_PROTOCOLS,
+        strip=True,
+    )
+    return bleach.linkify(
+        cleaned,
+        callbacks=[bleach.callbacks.nofollow, bleach.callbacks.target_blank],
+        parse_email=False,
+    )
+
+
+def markdown_to_html(text: str) -> str:
+    """Render Markdown into sanitized HTML."""
+    if not _MARKDOWN_AVAILABLE:
+        return escape_plain_text(text)
+
+    html_out = _markdown.markdown(
+        text,
+        extensions=["extra", "sane_lists", "nl2br", "codehilite"],
+        output_format="xhtml1",
+    )
+    return sanitize_html(html_out)
+
+
+def render_content_to_html(content: str, content_type: str, render_mode: str = "plain") -> str:
+    """Render email content to safe HTML based on the configured mode."""
+    ctype = (content_type or "text/plain").lower()
+    mode = (render_mode or "plain").lower()
+
+    if mode == "plain":
+        return escape_plain_text(content)
+
+    if mode == "markdown":
+        if ctype == "text/html":
+            return sanitize_html(content)
+        return markdown_to_html(content)
+
+    if ctype == "text/html":
+        return sanitize_html(content)
+    if ctype in ("text/markdown", "text/x-markdown"):
+        return markdown_to_html(content)
+    return escape_plain_text(content)

--- a/email_blog_server.py
+++ b/email_blog_server.py
@@ -1,545 +1,221 @@
+"""Serve an IMAP-backed email blog over HTTP."""
+
+from __future__ import annotations
+
 import asyncio
-import email
-import html
 import logging
 import signal
-import ssl
 from collections import deque
-from datetime import datetime, timezone
-from email.header import decode_header
-from email.utils import formatdate, parsedate_to_datetime
 from pathlib import Path
+from threading import RLock
 
 from aiohttp import web
-from aioimaplib import aioimaplib
 
-# Configure logging
-logging.basicConfig(level=logging.INFO)
+from email_blog_config import (
+    CONTENT_SECURITY_POLICY,
+    DEFAULT_MAX_BODY_CHARS,
+    DEFAULT_MAX_EMAIL_BYTES,
+    request_has_token,
+    validate_exposure,
+    validate_public_url,
+)
+from email_blog_feed import build_rss
+from email_blog_html import build_blog_html, build_email_html
+from email_blog_imap import EmailBlogImapMixin
+from email_blog_messages import (
+    extract_email_content,
+    safe_decode,
+)
+from email_blog_rendering import render_content_to_html
+
 logger = logging.getLogger(__name__)
 
-# Store emails in memory (recent 100 emails)
-emails_cache = deque(maxlen=100)
-# Track processed email UIDs to prevent duplicates
-processed_uids = set()
 
-# Optional dependencies for Markdown rendering and HTML sanitization
-try:
-    import markdown as _markdown  # type: ignore
-    _MARKDOWN_AVAILABLE = True
-except Exception:  # optional dependency
-    _markdown = None
-    _MARKDOWN_AVAILABLE = False
+class EmailBlogServer(EmailBlogImapMixin):
+    """Host a small HTTP blog populated from an IMAP mailbox."""
 
-try:
-    import bleach  # type: ignore
-    _BLEACH_AVAILABLE = True
-except Exception:  # optional dependency
-    bleach = None
-    _BLEACH_AVAILABLE = False
-
-
-class EmailBlogServer:
     def __init__(
         self,
-        imap_server,
-        email_addr,
-        password,
-        host="0.0.0.0",
-        port=8080,
-        blog_title=None,
-        public_url=None,
+        imap_server: str,
+        email_addr: str,
+        password: str,
+        host: str = "127.0.0.1",
+        port: int = 8080,
+        blog_title: str | None = None,
+        public_url: str | None = None,
         enable_imap: bool = True,
-        render_mode: str = "plain",  # 'plain' | 'markdown' | 'auto'
+        render_mode: str = "plain",
+        mailbox: str = "INBOX",
+        access_token: str | None = None,
+        allowed_senders: list[str] | None = None,
+        max_email_bytes: int = DEFAULT_MAX_EMAIL_BYTES,
+        max_body_chars: int = DEFAULT_MAX_BODY_CHARS,
+        allow_public_bind: bool = False,
+        allow_public_without_auth: bool = False,
     ):
         self.imap_server = imap_server
         self.email_addr = email_addr
         self.password = password
         self.host = host
         self.port = port
-        self.public_url = public_url
+        self.blog_title = blog_title or "Live Email Blog"
+        self.public_url = validate_public_url(public_url) if public_url else None
         self.enable_imap = enable_imap
         self.render_mode = (render_mode or "plain").lower()
+        self.mailbox = mailbox or "INBOX"
+        self.access_token = access_token
+        self.allowed_senders = allowed_senders or []
+        self.max_email_bytes = max_email_bytes
+        self.max_body_chars = max_body_chars
+
+        validate_exposure(host, access_token, allow_public_bind, allow_public_without_auth)
+
+        self.emails_cache: deque[dict[str, str]] = deque(maxlen=100)
+        self.processed_uids: set[str] = set()
+        self.uid_validity: str | None = None
+        self._cache_lock = RLock()
+        self._monitor_task: asyncio.Task | None = None
+        self._runner: web.AppRunner | None = None
+        self._closed_event: asyncio.Event | None = None
         self.imap_client = None
+
         self.app = web.Application()
         self.app.router.add_get("/", self.handle_blog)
         self.app.router.add_get("/health", self.handle_health)
         self.app.router.add_get("/email/{uid}", self.handle_single_email)
         self.app.router.add_get("/feed.xml", self.handle_rss)
-        self.blog_title = blog_title or "Live Email Blog"
         self.template_path = Path(__file__).parent / "templates" / "blog_template.html"
-        self.setup_signal_handlers()
 
-    def setup_signal_handlers(self):
-        """Setup graceful shutdown handlers"""
-
-        async def shutdown(sig):
-            logger.info(f"Received exit signal {sig.name}...")
-            tasks = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
-
-            # Cancel IMAP IDLE if active
-            if self.imap_client and self.imap_client.has_pending_idle():
-                try:
-                    await self.imap_client.idle_done()
-                except Exception as e:
-                    logger.error(f"Error during IDLE cleanup: {e}")
-
-            # Cancel all running tasks
-            [task.cancel() for task in tasks]
-
-            logger.info(f"Cancelling {len(tasks)} outstanding tasks")
-            await asyncio.gather(*tasks, return_exceptions=True)
-
-            # Shutdown the web application
-            await self.app.shutdown()
-            await self.app.cleanup()
-
-            # Stop the event loop
-            asyncio.get_event_loop().stop()
-
-        def handle_signal(sig):
-            loop = asyncio.get_running_loop()
-            loop.create_task(shutdown(sig))
-
-        # Register signal handlers
-        for sig in (signal.SIGTERM, signal.SIGINT):
-            try:
-                asyncio.get_running_loop().add_signal_handler(sig, lambda s=sig: handle_signal(s))
-            except (NotImplementedError, RuntimeError):
-                # Signal handlers may not be available (e.g., on Windows or if no running loop)
-                pass
-
-    async def connect_imap(self):
-        """Establish secure IMAP connection"""
-        try:
-            # Create SSL context with secure defaults
-            ssl_context = ssl.create_default_context()
-
-            logger.info(f"Creating IMAP client for {self.imap_server}")
-            self.imap_client = aioimaplib.IMAP4_SSL(host=self.imap_server, ssl_context=ssl_context)
-
-            logger.info("Waiting for server hello...")
-            try:
-                await self.imap_client.wait_hello_from_server()
-            except Exception as e:
-                logger.error(f"Failed at hello: {str(e)}", exc_info=True)
-                raise
-
-            logger.info("Attempting login...")
-            try:
-                await self.imap_client.login(self.email_addr, self.password)
-            except Exception as e:
-                logger.error(f"Failed at login: {str(e)}", exc_info=True)
-                raise
-
-            logger.info("Selecting INBOX...")
-            try:
-                await self.imap_client.select("INBOX")
-            except Exception as e:
-                logger.error(f"Failed at select: {str(e)}", exc_info=True)
-                raise
-
-            logger.info("Successfully connected to IMAP server")
-            return True
-        except Exception as e:
-            logger.error(f"Failed to connect to IMAP: {str(e)}", exc_info=True)
-            return False
-
-    @staticmethod
-    def safe_decode(header):
-        """Safely decode email headers"""
-        if not header:
-            return ""
-        decoded_header = decode_header(header)
-        parts = []
-        for content, charset in decoded_header:
-            if isinstance(content, bytes):
-                try:
-                    parts.append(content.decode(charset or "utf-8", errors="replace"))
-                except Exception:
-                    parts.append(content.decode("utf-8", errors="replace"))
-            else:
-                parts.append(str(content))
-        return " ".join(parts)
-
-    @staticmethod
-    def get_email_content(msg):
-        """Extract best available email content and its MIME type.
-
-        Preference: text/html -> text/markdown -> text/plain
-        Returns (content, content_type)
-        """
-        html_part = None
-        md_part = None
-        plain_part = None
-
-        def _decode(part):
-            try:
-                return part.get_payload(decode=True).decode(errors="replace")
-            except Exception:
-                return None
-
-        if msg.is_multipart():
-            for part in msg.walk():
-                ctype = part.get_content_type()
-                if ctype == "text/html" and html_part is None:
-                    html_part = _decode(part)
-                elif ctype in ("text/markdown", "text/x-markdown") and md_part is None:
-                    md_part = _decode(part)
-                elif ctype == "text/plain" and plain_part is None:
-                    plain_part = _decode(part)
-        else:
-            ctype = msg.get_content_type() or "text/plain"
-            body = _decode(msg)
-            if ctype == "text/html":
-                html_part = body
-            elif ctype in ("text/markdown", "text/x-markdown"):
-                md_part = body
-            else:
-                plain_part = body
-
-        if html_part is not None:
-            return html_part, "text/html"
-        if md_part is not None:
-            return md_part, "text/markdown"
-        if plain_part is not None:
-            return plain_part, "text/plain"
-        return "Could not decode email content", "text/plain"
+    safe_decode = staticmethod(safe_decode)
+    get_email_content = staticmethod(extract_email_content)
 
     def render_content_to_html(self, content: str, content_type: str) -> str:
-        """Render content to safe HTML based on configured render_mode."""
-        ctype = (content_type or "text/plain").lower()
-        mode = self.render_mode
+        """Render email content to safe HTML using this server's mode."""
+        return render_content_to_html(content, content_type, self.render_mode)
 
-        def _escape_plain(text: str) -> str:
-            return html.escape(text).replace(chr(10), "<br>")
-
-        def _sanitize(html_in: str) -> str:
-            if not _BLEACH_AVAILABLE:
-                return _escape_plain(html_in)
-            allowed_tags = [
-                "p",
-                "br",
-                "hr",
-                "pre",
-                "code",
-                "blockquote",
-                "ul",
-                "ol",
-                "li",
-                "strong",
-                "em",
-                "b",
-                "i",
-                "u",
-                "s",
-                "a",
-                "h1",
-                "h2",
-                "h3",
-                "h4",
-                "h5",
-                "h6",
-            ]
-            allowed_attrs = {"a": ["href", "title", "rel"]}
-            cleaned = bleach.clean(
-                html_in,
-                tags=allowed_tags,
-                attributes=allowed_attrs,
-                protocols=["http", "https", "mailto"],
-                strip=True,
-            )
-            return bleach.linkify(cleaned) if _BLEACH_AVAILABLE else cleaned
-
-        def _md_to_html(text: str) -> str:
-            if not _MARKDOWN_AVAILABLE:
-                return _escape_plain(text)
-            html_out = _markdown.markdown(
-                text,
-                extensions=["extra", "sane_lists", "nl2br", "codehilite"],
-                output_format="xhtml1",
-            )
-            return _sanitize(html_out)
-
-        if mode == "plain":
-            return _escape_plain(content)
-
-        if mode == "markdown":
-            if ctype == "text/html":
-                return _sanitize(content)
-            return _md_to_html(content)
-
-        # auto (or unknown) mode
-        if ctype == "text/html":
-            return _sanitize(content)
-        if ctype in ("text/markdown", "text/x-markdown"):
-            return _md_to_html(content)
-        return _escape_plain(content)
-
-    async def fetch_email(self, msg_id):
-        """Fetch and process a single email by sequence ID."""
-        try:
-            status, data = await self.imap_client.fetch(msg_id, "(RFC822)")
-        except Exception as e:
-            logger.error(f"Fetch failed for {msg_id}: {e}")
-            return None
-
-        if status == "OK" and isinstance(data, list) and data:
-            # Try common data shapes from IMAP responses
-            msg_bytes = None
-            first = data[0]
-            if (
-                isinstance(first, tuple)
-                and len(first) > 1
-                and isinstance(first[1], bytes | bytearray)
-            ):
-                msg_bytes = first[1]
-            else:
-                # Sometimes payload is the second list element
-                if len(data) > 1 and isinstance(data[1], bytes | bytearray):
-                    msg_bytes = data[1]
-
-            if not msg_bytes:
-                logger.error(f"Unexpected FETCH response format for {msg_id}: {data}")
-                return None
-
-            msg = email.message_from_bytes(msg_bytes)
-
-            # Safely extract and encode email details
-            subject = self.safe_decode(msg["subject"])
-            from_addr = self.safe_decode(msg["from"])
-            date = self.safe_decode(msg["date"])
-            content, content_type = self.get_email_content(msg)
-
-            return {
-                "subject": subject,
-                "from": from_addr,
-                "date": date,
-                "content": content,
-                "content_type": content_type,
-                "uid": msg_id,
-            }
-        return None
-
-    async def monitor_inbox(self):
-        """Monitor inbox for new emails"""
-        while True:
-            try:
-                # Create or re-create connection
-                logger.info(f"Connecting to {self.imap_server} as {self.email_addr}")
-                ok = await self.connect_imap()
-                if not ok:
-                    await asyncio.sleep(10)
-                    continue
-
-                logger.info("Searching for emails (sequence IDs)...")
-                status, data = await self.imap_client.search("ALL")
-                email_ids = []
-                if status == "OK" and data and isinstance(data[0], bytes | bytearray):
-                    email_ids = data[0].split()
-                logger.info(f"Found {len(email_ids)} emails")
-
-                # Fetch and cache emails
-                if email_ids:
-                    for email_id in email_ids[-100:]:  # Get last 100 emails
-                        seq_id = email_id.decode()
-                        if seq_id not in processed_uids:  # Only process new emails
-                            logger.info(f"Fetching email {seq_id}...")
-                            email_data = await self.fetch_email(seq_id)
-                            if email_data:
-                                emails_cache.appendleft(email_data)
-                                processed_uids.add(seq_id)
-
-                # Start IDLE mode
-                logger.info("Starting IDLE mode...")
-                await self.imap_client.idle_start()
-                try:
-                    while True:
-                        logger.info("Waiting for new emails...")
-                        response = await self.imap_client.wait_server_push()
-
-                        if response is None:
-                            logger.info("IDLE connection closed, reconnecting...")
-                            break
-
-                        logger.info(f"Received server push: {response}")
-
-                        # Check for new messages
-                        if any(b"EXISTS" in line for line in response):
-                            logger.info("New email detected!")
-                            await self.imap_client.idle_done()
-
-                            # Search for new messages only (simple diff)
-                            status, data = await self.imap_client.search("ALL")
-                            email_ids = []
-                            if status == "OK" and data and isinstance(data[0], bytes | bytearray):
-                                email_ids = data[0].split()
-                            # Process only new emails
-                            for email_id in email_ids:
-                                seq_id = email_id.decode()
-                                if seq_id not in processed_uids:
-                                    email_data = await self.fetch_email(seq_id)
-                                    if email_data:
-                                        emails_cache.appendleft(email_data)
-                                        processed_uids.add(seq_id)
-                                        logger.info(f"New email fetched: {email_data['subject']}")
-
-                            await self.imap_client.idle_start()
-
-                except Exception as e:
-                    logger.error(f"Error in IDLE loop: {str(e)}")
-                    await asyncio.sleep(5)
-
-            except Exception as e:
-                logger.error(f"Error in monitor_inbox: {str(e)}")
-                await asyncio.sleep(30)
-
-    def generate_html(self, single_email=None):
-        """Generate HTML blog content"""
-        # Generate email content HTML
-        email_content = ""
-        if single_email:
-            # Display single email
-            email_content = self.generate_email_html(single_email)
-        else:
-            # Display all emails with links
-            for email_data in emails_cache:
-                email_content += f"""
-        <article>
-            <h2><a href="/email/{email_data['uid']}">{html.escape(email_data['subject'])}</a></h2>
-            <div class="meta">
-                <p><strong>From:</strong> {html.escape(email_data['from'])}</p>
-                <p><strong>Date:</strong> {html.escape(email_data['date'])}</p>
-            </div>
-            <div class="content">
-                {self.render_content_to_html(email_data.get('content', ''), email_data.get('content_type') or 'text/plain')}
-            </div>
-        </article>"""
-
-        # Read template file
-        with open(self.template_path) as f:
-            template = f.read()
-
-        # Replace template variables manually to avoid conflicts with CSS
-        replacements = {
-            "{title}": html.escape(self.blog_title),
-            "{last_updated}": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
-            "{email_content}": email_content,
-        }
-        html_content = template
-        for key, value in replacements.items():
-            html_content = html_content.replace(key, value)
-
-        return html_content
-
-    def generate_email_html(self, email_data):
-        """Generate HTML for a single email"""
-        return f"""
-        <article>
-            <h2>{html.escape(email_data['subject'])}</h2>
-            <div class="meta">
-                <p><strong>From:</strong> {html.escape(email_data['from'])}</p>
-                <p><strong>Date:</strong> {html.escape(email_data['date'])}</p>
-            </div>
-            <div class="content">
-                {self.render_content_to_html(email_data.get('content', ''), email_data.get('content_type') or 'text/plain')}
-            </div>
-            <p><a href="/">← Back to all emails</a></p>
-        </article>"""
-
-    def generate_rss(self):
-        """Generate RSS feed content"""
-        items = []
-        base_url = (
-            self.public_url.rstrip("/") if self.public_url else f"http://{self.host}:{self.port}"
-        )
-        for email_data in emails_cache:
-            # Parse date robustly
-            try:
-                dt = parsedate_to_datetime(email_data["date"])
-                if dt is None:
-                    raise ValueError("parsedate_to_datetime returned None")
-                if dt.tzinfo is None:
-                    dt = dt.replace(tzinfo=timezone.utc)
-                pub_ts = float(dt.timestamp())
-            except Exception:
-                pub_ts = float(datetime.now(tz=timezone.utc).timestamp())
-
-            item = f"""
-            <item>
-                <title>{html.escape(email_data['subject'])}</title>
-                <link>{base_url}/email/{email_data['uid']}</link>
-                <guid>{base_url}/email/{email_data['uid']}</guid>
-                <description>{html.escape(email_data['content'])}</description>
-                <author>{html.escape(email_data['from'])}</author>
-                <pubDate>{formatdate(pub_ts)}</pubDate>
-            </item>"""
-            items.append(item)
-
-        rss = f"""<?xml version="1.0" encoding="UTF-8" ?>
-<rss version="2.0">
-    <channel>
-        <title>{html.escape(self.blog_title)}</title>
-        <link>{base_url}</link>
-        <description>{self.blog_title}</description>
-        <language>en-us</language>
-        <lastBuildDate>{formatdate()}</lastBuildDate>
-        {''.join(items)}
-    </channel>
-</rss>"""
-        return rss
-
-    async def handle_blog(self, request):
-        """Handle blog page requests"""
-        return web.Response(
-            text=self.generate_html(),
-            content_type="text/html",
-            headers={
-                "X-Content-Type-Options": "nosniff",
-                "X-Frame-Options": "DENY",
-                "Content-Security-Policy": "default-src 'none'; style-src 'unsafe-inline'; base-uri 'self';",
-            },
+    def generate_html(self, single_email: dict[str, str] | None = None) -> str:
+        """Generate HTML blog content."""
+        return build_blog_html(
+            self.template_path,
+            self.blog_title,
+            self._emails(),
+            self.render_mode,
+            single_email,
         )
 
-    async def handle_single_email(self, request):
-        """Handle single email view requests"""
+    def generate_email_html(self, email_data: dict[str, str], linked: bool = False) -> str:
+        """Generate HTML for one email post."""
+        return build_email_html(email_data, self.render_mode, linked)
+
+    def generate_rss(self) -> str:
+        """Generate an XML-safe RSS feed."""
+        return build_rss(self._emails(), self.blog_title, self._base_url())
+
+    async def handle_blog(self, request: web.Request) -> web.Response:
+        """Handle blog page requests."""
+        self._require_auth(request)
+        return self._html_response(self.generate_html())
+
+    async def handle_single_email(self, request: web.Request) -> web.Response:
+        """Handle single email view requests."""
+        self._require_auth(request)
         uid = request.match_info["uid"]
-        email_data = next((email for email in emails_cache if str(email["uid"]) == str(uid)), None)
-
+        email_data = next(
+            (email for email in self._emails() if str(email["uid"]) == str(uid)), None
+        )
         if not email_data:
             raise web.HTTPNotFound(text="Email not found")
+        return self._html_response(self.generate_html(single_email=email_data))
 
-        return web.Response(
-            text=self.generate_html(single_email=email_data),
-            content_type="text/html",
-            headers={
-                "X-Content-Type-Options": "nosniff",
-                "X-Frame-Options": "DENY",
-                "Content-Security-Policy": "default-src 'none'; style-src 'unsafe-inline'; base-uri 'self';",
-            },
-        )
-
-    async def handle_rss(self, request):
-        """Handle RSS feed requests"""
+    async def handle_rss(self, request: web.Request) -> web.Response:
+        """Handle RSS feed requests."""
+        self._require_auth(request)
         return web.Response(
             text=self.generate_rss(),
             content_type="application/rss+xml",
+            headers={"X-Content-Type-Options": "nosniff"},
+        )
+
+    async def handle_health(self, request: web.Request | None) -> web.Response:
+        """Handle health check requests."""
+        return web.Response(text="OK")
+
+    async def start(self, register_signals: bool = True) -> None:
+        """Start the web server and optional IMAP monitor."""
+        if self._closed_event is None:
+            self._closed_event = asyncio.Event()
+        self._runner = web.AppRunner(self.app)
+        await self._runner.setup()
+        site = web.TCPSite(self._runner, self.host, self.port)
+        await site.start()
+
+        if self.enable_imap:
+            self._monitor_task = asyncio.create_task(self.monitor_inbox())
+        if register_signals:
+            self._setup_signal_handlers()
+        logger.info("Server started at http://%s:%s", self.host, self.port)
+
+    async def stop(self) -> None:
+        """Stop this server's own IMAP and HTTP resources."""
+        if self._monitor_task:
+            self._monitor_task.cancel()
+            await asyncio.gather(self._monitor_task, return_exceptions=True)
+            self._monitor_task = None
+
+        await self._close_imap()
+        if self._runner:
+            await self._runner.cleanup()
+            self._runner = None
+        if self._closed_event:
+            self._closed_event.set()
+
+    async def wait_closed(self) -> None:
+        """Block until the server is stopped."""
+        if self._closed_event is None:
+            self._closed_event = asyncio.Event()
+        await self._closed_event.wait()
+
+    def _append_email(self, email_data: dict[str, str]) -> None:
+        with self._cache_lock:
+            self.emails_cache.appendleft(email_data)
+
+    def _emails(self) -> list[dict[str, str]]:
+        with self._cache_lock:
+            return list(self.emails_cache)
+
+    def _base_url(self) -> str:
+        return (self.public_url or f"http://{self.host}:{self.port}").rstrip("/")
+
+    def _require_auth(self, request: web.Request | None) -> None:
+        if not self.access_token:
+            return
+        if not request or not request_has_token(request, self.access_token):
+            raise web.HTTPUnauthorized(
+                text="Unauthorized",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+
+    def _html_response(self, text: str) -> web.Response:
+        return web.Response(
+            text=text,
+            content_type="text/html",
             headers={
                 "X-Content-Type-Options": "nosniff",
+                "X-Frame-Options": "DENY",
+                "Content-Security-Policy": CONTENT_SECURITY_POLICY,
             },
         )
 
-    async def handle_health(self, request):
-        """Handle health check requests"""
-        return web.Response(text="OK")
+    def _setup_signal_handlers(self) -> None:
+        loop = asyncio.get_running_loop()
+        for sig in (signal.SIGTERM, signal.SIGINT):
+            try:
+                loop.add_signal_handler(
+                    sig, lambda s=sig: asyncio.create_task(self._stop_for_signal(s))
+                )
+            except (NotImplementedError, RuntimeError):
+                pass
 
-    async def start(self):
-        """Start the server and email monitor"""
-        # Start email monitoring in background (optional for tests)
-        if self.enable_imap:
-            asyncio.create_task(self.monitor_inbox())
-        # Start web server
-        runner = web.AppRunner(self.app)
-        await runner.setup()
-        site = web.TCPSite(runner, self.host, self.port)
-        await site.start()
-        logger.info(f"Server started at http://{self.host}:{self.port}")
+    async def _stop_for_signal(self, sig: signal.Signals) -> None:
+        logger.info("Received exit signal %s", sig.name)
+        await self.stop()

--- a/tests/test_message_processing.py
+++ b/tests/test_message_processing.py
@@ -119,6 +119,71 @@ class MessageProcessingTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertIsNone(await server.fetch_email("124"))
 
+    async def test_sender_allowlist_ignores_display_name(self):
+        msg = EmailMessage()
+        msg["From"] = '"allowed@example.com" <attacker@example.net>'
+        msg["Subject"] = "Spoof"
+        msg.set_content("hello")
+        raw = msg.as_bytes()
+
+        server = EmailBlogServer(
+            imap_server="imap.example.com",
+            email_addr="user@example.com",
+            password="secret",
+            host="127.0.0.1",
+            enable_imap=False,
+            allowed_senders=["allowed@example.com"],
+        )
+        server.imap_client = FakeImapClient(
+            {
+                ("FETCH", "125", "(RFC822.SIZE)"): (
+                    "OK",
+                    [f"1 (UID 125 RFC822.SIZE {len(raw)})".encode()],
+                ),
+                ("FETCH", "125", "(BODY.PEEK[])"): (
+                    "OK",
+                    [b"1 (UID 125 BODY[]", raw, b")"],
+                ),
+            }
+        )
+
+        self.assertIsNone(await server.fetch_email("125"))
+
+    async def test_startup_marks_older_uids_processed(self):
+        server = EmailBlogServer(
+            imap_server="imap.example.com",
+            email_addr="user@example.com",
+            password="secret",
+            host="127.0.0.1",
+            enable_imap=False,
+        )
+        server.imap_client = FakeImapClient(
+            {
+                ("SEARCH", "ALL"): ("OK", [b" ".join(str(uid).encode() for uid in range(1, 106))]),
+            }
+        )
+        fetched = []
+
+        async def fake_fetch_email(uid):
+            fetched.append(uid)
+            return {
+                "subject": f"Post {uid}",
+                "from": "User",
+                "date": "Mon, 01 Jan 2024 12:34:56 +0000",
+                "content": "Body",
+                "content_type": "text/plain",
+                "uid": uid,
+            }
+
+        server.fetch_email = fake_fetch_email
+
+        await server._fetch_new_uids(limit_to_recent=True)
+        await server._fetch_new_uids()
+
+        self.assertEqual(fetched, [str(uid) for uid in range(6, 106)])
+        self.assertEqual(server.processed_uids, {str(uid) for uid in range(1, 106)})
+        self.assertEqual(len(server.emails_cache), 100)
+
 
 class FakeImapClient:
     def __init__(self, responses):

--- a/tests/test_message_processing.py
+++ b/tests/test_message_processing.py
@@ -1,0 +1,135 @@
+import unittest
+from email.message import EmailMessage
+
+from email_blog_messages import extract_email_content
+from email_blog_server import EmailBlogServer
+
+
+class MessageProcessingTests(unittest.IsolatedAsyncioTestCase):
+    async def test_attachment_only_message_is_not_published_as_body(self):
+        msg = EmailMessage()
+        msg["From"] = "User <user@example.com>"
+        msg["Subject"] = "Attachment"
+        msg.make_mixed()
+        attachment = EmailMessage()
+        attachment.set_content("secret attachment only")
+        attachment.add_header("Content-Disposition", "attachment", filename="secret.txt")
+        msg.attach(attachment)
+
+        content, content_type = extract_email_content(msg)
+
+        self.assertEqual(content_type, "text/plain")
+        self.assertEqual(content, "Could not decode email content")
+
+    async def test_inline_body_wins_over_text_attachment(self):
+        msg = EmailMessage()
+        msg["From"] = "User <user@example.com>"
+        msg["Subject"] = "Body"
+        msg.set_content("public body")
+        msg.add_attachment("secret attachment", subtype="plain", filename="secret.txt")
+
+        content, content_type = extract_email_content(msg)
+
+        self.assertEqual(content_type, "text/plain")
+        self.assertEqual(content, "public body\n")
+
+    async def test_fetch_email_uses_uid_fetch_and_size_limit(self):
+        server = EmailBlogServer(
+            imap_server="imap.example.com",
+            email_addr="user@example.com",
+            password="secret",
+            host="127.0.0.1",
+            enable_imap=False,
+            max_email_bytes=20,
+        )
+        server.imap_client = FakeImapClient(
+            {
+                ("FETCH", "123", "(RFC822.SIZE)"): ("OK", [b"1 (UID 123 RFC822.SIZE 100)"]),
+            }
+        )
+
+        with self.assertLogs("email_blog_imap", level="WARNING"):
+            email_data = await server.fetch_email("123")
+
+        self.assertIsNone(email_data)
+        self.assertEqual(server.imap_client.calls, [("FETCH", "123", "(RFC822.SIZE)")])
+
+    async def test_fetch_email_stores_stable_uid(self):
+        msg = EmailMessage()
+        msg["From"] = "Allowed <allowed@example.com>"
+        msg["Subject"] = "UID Post"
+        msg["Date"] = "Mon, 01 Jan 2024 12:34:56 +0000"
+        msg.set_content("hello")
+        raw = msg.as_bytes()
+
+        server = EmailBlogServer(
+            imap_server="imap.example.com",
+            email_addr="user@example.com",
+            password="secret",
+            host="127.0.0.1",
+            enable_imap=False,
+            allowed_senders=["allowed@example.com"],
+        )
+        server.imap_client = FakeImapClient(
+            {
+                ("FETCH", "123", "(RFC822.SIZE)"): (
+                    "OK",
+                    [f"1 (UID 123 RFC822.SIZE {len(raw)})".encode()],
+                ),
+                ("FETCH", "123", "(BODY.PEEK[])"): (
+                    "OK",
+                    [b"1 (UID 123 BODY[]", raw, b")"],
+                ),
+            }
+        )
+
+        email_data = await server.fetch_email("123")
+
+        self.assertIsNotNone(email_data)
+        self.assertEqual(email_data["uid"], "123")
+        self.assertEqual(email_data["content"], "hello\n")
+
+    async def test_sender_allowlist_skips_untrusted_sender(self):
+        msg = EmailMessage()
+        msg["From"] = "Other <other@example.com>"
+        msg["Subject"] = "Skip"
+        msg.set_content("hello")
+        raw = msg.as_bytes()
+
+        server = EmailBlogServer(
+            imap_server="imap.example.com",
+            email_addr="user@example.com",
+            password="secret",
+            host="127.0.0.1",
+            enable_imap=False,
+            allowed_senders=["allowed@example.com"],
+        )
+        server.imap_client = FakeImapClient(
+            {
+                ("FETCH", "124", "(RFC822.SIZE)"): (
+                    "OK",
+                    [f"1 (UID 124 RFC822.SIZE {len(raw)})".encode()],
+                ),
+                ("FETCH", "124", "(BODY.PEEK[])"): (
+                    "OK",
+                    [b"1 (UID 124 BODY[]", raw, b")"],
+                ),
+            }
+        )
+
+        self.assertIsNone(await server.fetch_email("124"))
+
+
+class FakeImapClient:
+    def __init__(self, responses):
+        self.responses = responses
+        self.calls = []
+
+    async def uid(self, command, uid, parts=None):
+        call = (command, uid, parts) if parts else (command, uid)
+        self.calls.append(call)
+        return self.responses[call]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_render_mode.py
+++ b/tests/test_render_mode.py
@@ -1,13 +1,9 @@
 import unittest
 
-from email_blog_server import EmailBlogServer, emails_cache, processed_uids
+from email_blog_server import EmailBlogServer
 
 
 class RenderModeTests(unittest.IsolatedAsyncioTestCase):
-    def setUp(self):
-        emails_cache.clear()
-        processed_uids.clear()
-
     async def test_auto_prefers_html_and_blocks_script(self):
         server = EmailBlogServer(
             imap_server="imap.example.com",
@@ -21,7 +17,7 @@ class RenderModeTests(unittest.IsolatedAsyncioTestCase):
             render_mode="auto",
         )
 
-        emails_cache.appendleft(
+        server.emails_cache.appendleft(
             {
                 "subject": "HTML Email",
                 "from": "User",
@@ -52,7 +48,7 @@ class RenderModeTests(unittest.IsolatedAsyncioTestCase):
             render_mode="markdown",
         )
 
-        emails_cache.appendleft(
+        server.emails_cache.appendleft(
             {
                 "subject": "MD Email",
                 "from": "User",
@@ -79,7 +75,7 @@ class RenderModeTests(unittest.IsolatedAsyncioTestCase):
             enable_imap=False,
         )
         # Old entries without content_type should still render safely
-        emails_cache.appendleft(
+        server.emails_cache.appendleft(
             {
                 "subject": "Plain Email",
                 "from": "User",
@@ -95,4 +91,3 @@ class RenderModeTests(unittest.IsolatedAsyncioTestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,13 +1,14 @@
 import unittest
 from types import SimpleNamespace
+from xml.etree import ElementTree
 
-from email_blog_server import EmailBlogServer, emails_cache, processed_uids
+from aiohttp import web
+
+from email_blog_server import EmailBlogServer
 
 
 class EmailBlogServerTests(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
-        emails_cache.clear()
-        processed_uids.clear()
         self.server = EmailBlogServer(
             imap_server="imap.example.com",
             email_addr="user@example.com",
@@ -31,7 +32,7 @@ class EmailBlogServerTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("Content-Security-Policy", resp.headers)
 
     async def test_blog_with_email_and_escape(self):
-        emails_cache.appendleft(
+        self.server.emails_cache.appendleft(
             {
                 "subject": "Hello <b>X</b>",
                 "from": "User <script>",
@@ -46,7 +47,7 @@ class EmailBlogServerTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("Line1<br>Line2&lt;script&gt;", html)
 
     async def test_single_email_found_and_not_found(self):
-        emails_cache.appendleft(
+        self.server.emails_cache.appendleft(
             {
                 "subject": "Post",
                 "from": "User",
@@ -67,7 +68,7 @@ class EmailBlogServerTests(unittest.IsolatedAsyncioTestCase):
             await self.server.handle_single_email(req2)
 
     async def test_rss_uses_public_url_and_parses_date(self):
-        emails_cache.appendleft(
+        self.server.emails_cache.appendleft(
             {
                 "subject": "RSS Item",
                 "from": "User",
@@ -82,6 +83,102 @@ class EmailBlogServerTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("<title>RSS Item</title>", xml)
         self.assertIn("http://example.com/email/10", xml)
         self.assertIn("<pubDate>", xml)
+        ElementTree.fromstring(xml.split("\n", 1)[1])
+
+    async def test_rss_escapes_channel_fields(self):
+        server = EmailBlogServer(
+            imap_server="imap.example.com",
+            email_addr="user@example.com",
+            password="secret",
+            host="127.0.0.1",
+            port=8081,
+            blog_title="Bad <title> & Blog",
+            public_url="https://example.com/blog?a=1&b=2",
+            enable_imap=False,
+        )
+        xml = (await server.handle_rss(None)).text
+        parsed = ElementTree.fromstring(xml.split("\n", 1)[1])
+        channel = parsed.find("channel")
+        self.assertIsNotNone(channel)
+        self.assertEqual(channel.findtext("description"), "Bad <title> & Blog")
+        self.assertEqual(channel.findtext("link"), "https://example.com/blog?a=1&b=2")
+
+    async def test_access_token_required_for_content_routes(self):
+        server = EmailBlogServer(
+            imap_server="imap.example.com",
+            email_addr="user@example.com",
+            password="secret",
+            host="127.0.0.1",
+            port=8081,
+            access_token="token",
+            enable_imap=False,
+        )
+
+        with self.assertRaises(web.HTTPUnauthorized):
+            await server.handle_blog(SimpleNamespace(headers={}, query={}))
+
+        req = SimpleNamespace(headers={"Authorization": "Bearer token"}, query={})
+        resp = await server.handle_blog(req)
+        self.assertEqual(resp.status, 200)
+
+    async def test_public_bind_requires_explicit_opt_in_and_auth(self):
+        with self.assertRaisesRegex(ValueError, "ALLOW_PUBLIC_BIND"):
+            EmailBlogServer("imap.example.com", "user@example.com", "secret", host="0.0.0.0")
+
+        with self.assertRaisesRegex(ValueError, "BLOG_ACCESS_TOKEN"):
+            EmailBlogServer(
+                "imap.example.com",
+                "user@example.com",
+                "secret",
+                host="0.0.0.0",
+                allow_public_bind=True,
+            )
+
+        server = EmailBlogServer(
+            "imap.example.com",
+            "user@example.com",
+            "secret",
+            host="0.0.0.0",
+            access_token="token",
+            allow_public_bind=True,
+        )
+        self.assertEqual(server.host, "0.0.0.0")
+
+    async def test_start_stop_cleans_only_owned_resources(self):
+        server = EmailBlogServer(
+            imap_server="imap.example.com",
+            email_addr="user@example.com",
+            password="secret",
+            host="127.0.0.1",
+            port=0,
+            enable_imap=False,
+        )
+
+        await server.start(register_signals=False)
+        await server.stop()
+        await server.wait_closed()
+
+        self.assertIsNone(server._runner)
+
+    async def test_uid_validity_change_clears_instance_state(self):
+        self.server.uid_validity = "1"
+        self.server.processed_uids.add("10")
+        self.server.emails_cache.appendleft(
+            {
+                "subject": "Post",
+                "from": "User",
+                "date": "Mon, 01 Jan 2024 12:34:56 +0000",
+                "content": "Body",
+                "uid": "10",
+            }
+        )
+
+        with self.assertLogs("email_blog_imap", level="WARNING"):
+            self.server._set_uid_validity("2")
+
+        self.assertEqual(self.server.uid_validity, "2")
+        self.assertEqual(list(self.server.emails_cache), [])
+        self.assertEqual(self.server.processed_uids, set())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- lock down public exposure defaults with loopback binding, explicit public-bind opt-in, optional token auth, mailbox selection, and sender allowlisting
- refactor the monolithic server into focused IMAP, MIME parsing, rendering, RSS, HTML, and config modules
- switch ingestion to stable IMAP UID search/fetch with UIDVALIDITY handling, message/body limits, and attachment skipping
- generate XML-safe RSS, move cache state onto server instances, clean up lifecycle handling, and add CI

## Validation
- make test
- make lint
- make format-check
- .venv/bin/pip-audit -r requirements.txt